### PR TITLE
Add SQLite persistence for activities and registrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.log
 *.sql
 *.sqlite
+*.db
 
 # OS generated files #
 ######################

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Data persists across server restarts with SQLite
 
 ## Getting Started
 
@@ -18,7 +19,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn app:app --reload
    ```
 
 3. Open your browser and go to:
@@ -31,20 +32,32 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student from an activity                            |
 
 ## Data Model
 
-The application uses a simple data model with meaningful identifiers:
+The application now uses SQLite (`school.db`) and initializes schema on startup.
 
-1. **Activities** - Uses activity name as identifier:
+Tables:
+
+1. **activities**
 
    - Description
    - Schedule
    - Maximum number of participants allowed
-   - List of student emails who are signed up
+   - Unique activity name
 
-2. **Students** - Uses email as identifier:
-   - Name
-   - Grade level
+2. **users**
 
-All data is stored in memory, which means data will be reset when the server restarts.
+   - Email (primary key)
+
+3. **registrations**
+
+   - Many-to-many link between activities and users
+
+## Database Initialization and Reset
+
+- On first startup, the app creates tables and seeds default activities.
+- DB file location: `src/school.db`
+- To reset to a clean seeded state, stop the server and delete `src/school.db`, then restart.
+

--- a/src/app.py
+++ b/src/app.py
@@ -10,72 +10,164 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import sqlite3
+
+
+def _seed_activities() -> list[dict[str, object]]:
+    return [
+        {
+            "name": "Chess Club",
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+            "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+        },
+        {
+            "name": "Programming Class",
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+            "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+        },
+        {
+            "name": "Gym Class",
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+            "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+        },
+        {
+            "name": "Soccer Team",
+            "description": "Join the school soccer team and compete in matches",
+            "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+            "max_participants": 22,
+            "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+        },
+        {
+            "name": "Basketball Team",
+            "description": "Practice and play basketball with the school team",
+            "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+        },
+        {
+            "name": "Art Club",
+            "description": "Explore your creativity through painting and drawing",
+            "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+        },
+        {
+            "name": "Drama Club",
+            "description": "Act, direct, and produce plays and performances",
+            "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+            "max_participants": 20,
+            "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+        },
+        {
+            "name": "Math Club",
+            "description": "Solve challenging problems and participate in math competitions",
+            "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+            "max_participants": 10,
+            "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+        },
+        {
+            "name": "Debate Team",
+            "description": "Develop public speaking and argumentation skills",
+            "schedule": "Fridays, 4:00 PM - 5:30 PM",
+            "max_participants": 12,
+            "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+        },
+    ]
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
+DB_PATH = Path(__file__).parent / "school.db"
+
+
+def get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def initialize_database() -> None:
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                email TEXT PRIMARY KEY,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS activities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL CHECK (max_participants > 0),
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS registrations (
+                activity_id INTEGER NOT NULL,
+                user_email TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (activity_id, user_email),
+                FOREIGN KEY(activity_id) REFERENCES activities(id) ON DELETE CASCADE,
+                FOREIGN KEY(user_email) REFERENCES users(email) ON DELETE CASCADE
+            )
+            """
+        )
+
+        existing = cursor.execute("SELECT COUNT(*) AS c FROM activities").fetchone()["c"]
+        if existing == 0:
+            for activity in _seed_activities():
+                cursor.execute(
+                    """
+                    INSERT INTO activities (name, description, schedule, max_participants)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        activity["name"],
+                        activity["description"],
+                        activity["schedule"],
+                        activity["max_participants"],
+                    ),
+                )
+                activity_id = cursor.lastrowid
+                for email in activity["participants"]:
+                    cursor.execute(
+                        "INSERT OR IGNORE INTO users (email) VALUES (?)",
+                        (email,),
+                    )
+                    cursor.execute(
+                        """
+                        INSERT OR IGNORE INTO registrations (activity_id, user_email)
+                        VALUES (?, ?)
+                        """,
+                        (activity_id, email),
+                    )
+
+        conn.commit()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    initialize_database()
+
 # Mount the static files directory
-current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
-
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
 
 
 @app.get("/")
@@ -85,48 +177,106 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT
+                a.id,
+                a.name,
+                a.description,
+                a.schedule,
+                a.max_participants
+            FROM activities a
+            ORDER BY a.name
+            """
+        ).fetchall()
+
+        data: dict[str, dict[str, object]] = {}
+        for row in rows:
+            participant_rows = conn.execute(
+                """
+                SELECT user_email
+                FROM registrations
+                WHERE activity_id = ?
+                ORDER BY user_email
+                """,
+                (row["id"],),
+            ).fetchall()
+            participants = [participant["user_email"] for participant in participant_rows]
+
+            data[row["name"]] = {
+                "description": row["description"],
+                "schedule": row["schedule"],
+                "max_participants": row["max_participants"],
+                "participants": participants,
+            }
+    return data
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as conn:
+        activity = conn.execute(
+            "SELECT id FROM activities WHERE name = ?",
+            (activity_name,),
+        ).fetchone()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        already_registered = conn.execute(
+            """
+            SELECT 1 FROM registrations
+            WHERE activity_id = ? AND user_email = ?
+            """,
+            (activity["id"], email),
+        ).fetchone()
+        if already_registered:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is already signed up"
+            )
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
+        conn.execute(
+            "INSERT OR IGNORE INTO users (email) VALUES (?)",
+            (email,),
         )
+        conn.execute(
+            """
+            INSERT INTO registrations (activity_id, user_email)
+            VALUES (?, ?)
+            """,
+            (activity["id"], email),
+        )
+        conn.commit()
 
-    # Add student
-    activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as conn:
+        activity = conn.execute(
+            "SELECT id FROM activities WHERE name = ?",
+            (activity_name,),
+        ).fetchone()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        deleted = conn.execute(
+            """
+            DELETE FROM registrations
+            WHERE activity_id = ? AND user_email = ?
+            """,
+            (activity["id"], email),
         )
+        if deleted.rowcount == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity"
+            )
 
-    # Remove student
-    activity["participants"].remove(email)
+        conn.commit()
+
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
## Summary
- replace in-memory activity storage with SQLite-backed persistence
- add startup DB initialization + seed data for activities/users/registrations
- preserve existing activities/signup/unregister API behavior
- update docs for DB usage and add .db ignore rule

## Validation
- started app and verified GET /activities
- verified signup writes to DB
- restarted app and confirmed signup persists across restarts